### PR TITLE
Fix Next.js build by correcting CSS import

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import './globals.css'
+import '../styles/globals.css'
 import { ReactNode } from 'react'
 
 export const metadata = {


### PR DESCRIPTION
## Summary
- fix the import path for `globals.css`

## Testing
- `npm run build` *(fails: `next` not found)*