### PR TITLE
Fix build with Tailwind PostCSS plugin

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import './globals.css'
+import '../styles/globals.css'
 import { ReactNode } from 'react'
 
 export const metadata = {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "tailwindcss": "latest",
     "postcss": "latest",
     "autoprefixer": "latest",
+    "@tailwindcss/postcss": "latest",
     "eslint": "latest",
     "eslint-config-next": "latest"
   }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
## Summary
- install `@tailwindcss/postcss`
- use `@tailwindcss/postcss` plugin in PostCSS config

## Testing
- `npm install --offline` *(fails: cache mode error)*
- `npm run build` *(fails: `next` not found)*