### PR TITLE
Add Jest testing framework setup

### DIFF
--- a/components/__tests__/Nav.test.tsx
+++ b/components/__tests__/Nav.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import Nav from '../Nav'
+import { useRouter } from 'next/navigation'
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}))
+
+describe('Nav component', () => {
+  it('renders navigation links', () => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() })
+    render(<Nav />)
+    expect(screen.getByText('Mrcto Consulting')).toBeInTheDocument()
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.getByText('Services')).toBeInTheDocument()
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+/** @type {import('jest').Config} */
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testEnvironment: 'jest-environment-jsdom',
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "next": "latest",
@@ -23,6 +24,12 @@
     "autoprefixer": "latest",
     "@tailwindcss/postcss": "latest",
     "eslint": "latest",
-    "eslint-config-next": "latest"
+    "eslint-config-next": "latest",
+    "jest": "latest",
+    "@types/jest": "latest",
+    "@testing-library/react": "latest",
+    "@testing-library/jest-dom": "latest",
+    "@testing-library/user-event": "latest",
+    "jest-environment-jsdom": "latest"
   }
 }


### PR DESCRIPTION
## Summary
- install Jest and Testing Library dependencies
- configure Jest using `next/jest`
- set up `jest.setup.ts` for jest-dom
- add sample test for `Nav` component

## Testing
- `npm test` *(fails: jest not found)*