### PR TITLE
Add ChatGPT support chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project was scaffolded without internet access. It sets up a basic **Next.j
 
 The site promotes responsible AI adoption for enterprises and small businesses. It includes a home page with a short overview and a services page describing how we can help with data protection, workflow integration, telemetry and ROI projections.
 
+There is also a customer support chat page powered by ChatGPT. Set an `OPENAI_API_KEY` environment variable when running the dev server to enable responses from OpenAI.
+
 **Disclaimer:** Generative AI can produce incorrect or misleading content, so results should always be reviewed by humans.
 
 ## Setup

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState } from 'react'
+
+export const metadata = {
+  title: 'Support Chat - Mrcto Consulting',
+  description: 'Real-time customer support powered by ChatGPT',
+}
+
+interface ChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export default function Chat() {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [input, setInput] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const sendMessage = async () => {
+    if (!input.trim()) return
+
+    const newMessages = [...messages, { role: 'user', content: input }]
+    setMessages(newMessages)
+    setInput('')
+    setLoading(true)
+
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: newMessages }),
+    })
+
+    const data = await res.json()
+    setMessages([...newMessages, { role: 'assistant', content: data.message }])
+    setLoading(false)
+  }
+
+  return (
+    <main className="max-w-2xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">Support Chat</h1>
+      <p className="text-sm text-gray-600">
+        This chat connects to OpenAI to answer your questions. Responses may be
+        incorrect or misleading, so always verify important information.
+      </p>
+      <div className="border rounded p-4 space-y-2 min-h-[300px] bg-white">
+        {messages.map((m, i) => (
+          <div key={i} className={m.role === 'user' ? 'text-right' : ''}>
+            <span className="font-semibold capitalize">{m.role}:</span>{' '}
+            {m.content}
+          </div>
+        ))}
+        {loading && <div>...</div>}
+      </div>
+      <div className="flex space-x-2">
+        <input
+          className="flex-1 border rounded p-2"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') sendMessage()
+          }}
+          placeholder="Type your question..."
+        />
+        <button
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+          onClick={sendMessage}
+          disabled={loading}
+        >
+          Send
+        </button>
+      </div>
+    </main>
+  )
+}

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -7,6 +7,7 @@ export default function Nav() {
       <div className="space-x-4">
         <Link href="/" className="hover:underline">Home</Link>
         <Link href="/services" className="hover:underline">Services</Link>
+        <Link href="/chat" className="hover:underline">Support Chat</Link>
       </div>
     </nav>
   )

--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.status(405).end('Method Not Allowed')
+    return
+  }
+
+  const { messages } = req.body
+
+  if (!process.env.OPENAI_API_KEY) {
+    res.status(500).json({ error: 'OpenAI API key not configured' })
+    return
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages,
+      })
+    })
+
+    if (!response.ok) {
+      const text = await response.text()
+      res.status(500).json({ error: text })
+      return
+    }
+
+    const data = await response.json()
+    res.status(200).json({
+      message: data.choices?.[0]?.message?.content || ''
+    })
+  } catch (err: any) {
+    res.status(500).json({ error: err.message })
+  }
+}


### PR DESCRIPTION
## Summary
- integrate a basic chat page that connects to ChatGPT via API
- add an API route to proxy chat requests
- expose link in navigation
- document the new feature and OPENAI_API_KEY requirement

## Testing
- `npm run lint` *(fails: next not found)*