### PR TITLE
Add analytics event store

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This project was scaffolded without internet access. It sets up a basic **Next.js** app using the modern `app/` router, **TypeScript**, and **Tailwind CSS**.
 
 The site promotes responsible AI adoption for enterprises and small businesses. It includes a home page with a short overview and a services page describing how we can help with data protection, workflow integration, telemetry and ROI projections.
+The app also includes a lightweight analytics toolset. Page views and custom events are sent to a local `/api/analytics` endpoint so you can measure engagement without relying on external services. Collected events can be viewed at `/api/analytics/stats` during development.
+
 
 **Disclaimer:** Generative AI can produce incorrect or misleading content, so results should always be reviewed by humans.
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import '../styles/globals.css'
 import { ReactNode } from 'react'
 import Nav from '../components/Nav'
+import Analytics from '../components/Analytics'
 
 export const metadata = {
   title: 'Mrcto Marketing',
@@ -12,6 +13,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en">
       <body className="min-h-screen bg-gray-100 text-gray-800">
         <Nav />
+        <Analytics />
         {children}
       </body>
     </html>

--- a/components/Analytics.tsx
+++ b/components/Analytics.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
+
+export default function Analytics() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    const url = searchParams.toString()
+      ? `${pathname}?${searchParams.toString()}`
+      : pathname
+    const event = { type: 'pageview', url, ts: Date.now() }
+
+    fetch('/api/analytics', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(event),
+    }).catch(err => {
+      console.error('Analytics error', err)
+    })
+  }, [pathname, searchParams])
+
+  return null
+}

--- a/lib/analyticsStore.ts
+++ b/lib/analyticsStore.ts
@@ -1,0 +1,12 @@
+let events: any[] = []
+
+export function addEvent(event: any) {
+  events.push(event)
+  if (events.length > 1000) {
+    events = events.slice(events.length - 1000)
+  }
+}
+
+export function getEvents() {
+  return events
+}

--- a/lib/useAnalytics.ts
+++ b/lib/useAnalytics.ts
@@ -1,0 +1,15 @@
+'use client'
+
+import { useCallback } from 'react'
+
+export function useAnalytics() {
+  return useCallback((event: Record<string, any>) => {
+    fetch('/api/analytics', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...event, ts: Date.now() }),
+    }).catch(err => {
+      console.error('Analytics error', err)
+    })
+  }, [])
+}

--- a/pages/api/analytics/index.ts
+++ b/pages/api/analytics/index.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { addEvent } from '../../lib/analyticsStore'
+
+type AnalyticsEvent = {
+  type: string
+  url?: string
+  [key: string]: any
+}
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ status: string } | string>
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).end('Method Not Allowed')
+  }
+
+  const event = req.body as AnalyticsEvent
+  addEvent(event)
+  console.log('Analytics event:', event)
+  res.status(200).json({ status: 'ok' })
+}

--- a/pages/api/analytics/stats.ts
+++ b/pages/api/analytics/stats.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getEvents } from '../../../lib/analyticsStore'
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET'])
+    return res.status(405).end('Method Not Allowed')
+  }
+
+  res.status(200).json({ events: getEvents() })
+}


### PR DESCRIPTION
## Summary
- store captured events in-memory on the server
- expose stats at `/api/analytics/stats`
- document how to view collected analytics

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*